### PR TITLE
Increment number default value changed from NULL to 0

### DIFF
--- a/fields/field.incrementnumber.php
+++ b/fields/field.incrementnumber.php
@@ -42,7 +42,7 @@
 				"CREATE TABLE IF NOT EXISTS `tbl_entries_data_" . $this->get('id') . "` (
 				  `id` int(11) unsigned NOT NULL auto_increment,
 				  `entry_id` int(11) unsigned NOT NULL,
-				  `value` double default NULL,
+				  `value` double default 0,
 				  PRIMARY KEY  (`id`),
 				  KEY `entry_id` (`entry_id`),
 				  KEY `value` (`value`)


### PR DESCRIPTION
The NULL default value caused the increment number not to work when added to sections with existing data. The manual workaround was to reset it's value.
